### PR TITLE
Don't report 504 as error to New Relic

### DIFF
--- a/newrelic.js
+++ b/newrelic.js
@@ -26,6 +26,6 @@ exports.config = {
    */
   error_collector : {
     enabled : true,
-    ignore_status_codes : [404,504]
+    ignore_status_codes : [403,404,504]
   }
 };

--- a/newrelic.js
+++ b/newrelic.js
@@ -21,4 +21,11 @@ exports.config = {
      */
     level : 'info'
   }
+  /**
+   * Don't report certain types of failures as errors
+   */
+  error_collector : {
+    enabled : true,
+    ignore_status_codes : [404,504]
+  }
 };

--- a/newrelic.js
+++ b/newrelic.js
@@ -20,7 +20,7 @@ exports.config = {
      * production applications.
      */
     level : 'info'
-  }
+  },
   /**
    * Don't report certain types of failures as errors
    */


### PR DESCRIPTION
504 is essentially ImgFlo's 404, so it shouldn't be sent to New Relic as an error in order to prevent false alarms.